### PR TITLE
Se crea el .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,38 @@
+# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see 
+http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+
+# archivos y carpetas generados por IDE Eclipse
+*.classpath
+*.project
+/bin/
+/.settings/
+
+# archivos y carpetas generadas por IDE Intellij Idea
+
+*.iml
+*.eml
+*.DS_Store
+/out/
+/.idea/


### PR DESCRIPTION
Se crea el .gitignore para que al abrirlo a los demás en los IDEs no afecten los archivos innecesarios